### PR TITLE
handle an edge case that only one sample in one group

### DIFF
--- a/R/internal_fns.R
+++ b/R/internal_fns.R
@@ -21,7 +21,7 @@ fraction_filter <- function(fraction_table, groupsamps,
                             fraction_samples_cutoff,
                             groupprop_filter_features) {
     ## apply filter fraction
-    groupfractab <- fraction_table[,groupsamps]
+    groupfractab <- fraction_table[,groupsamps, drop=F]
     groupfractab_select <- groupfractab[rowSums(
         groupfractab!=0, na.rm = TRUE)/ncol(groupfractab) >
             fraction_samples_cutoff,]


### PR DESCRIPTION
As a title, the program will stop if there is only one sample in one of two groups. The fundamental reason is that the data frame will become a vector in this case.